### PR TITLE
Update TF AWS EKS module

### DIFF
--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -4,6 +4,11 @@
 #
 #####
 
+locals{
+  # if AZs are explicitly defined as a variable, use those. Otherwise use all the AZs of the current region
+  # NOTE: the syntax should improve with Terraform 12
+  azs = "${split(",", length(var.availability_zones) != 0 ? join(",", var.availability_zones) : join(",", data.aws_availability_zones.available.names))}"
+}
 
 module "jupyter_pool" {
   source                       = "../eks-nodepool/"
@@ -77,8 +82,9 @@ resource "random_shuffle" "az" {
   #input = ["${data.aws_autoscaling_group.squid_auto.availability_zones}"]
   #input = ["${data.aws_availability_zones.available.names}"]
   #input = "${length(var.availability_zones) > 0 ? var.availability_zones : data.aws_autoscaling_group.squid_auto.availability_zones }"
-  input = "${var.availability_zones}"
-  result_count = 3
+  #input = "${var.availability_zones}"
+  input = "${local.azs}"
+  result_count = "${length(local.azs)}"
   count = 1
 }
 

--- a/tf_files/aws/modules/eks/variables.tf
+++ b/tf_files/aws/modules/eks/variables.tf
@@ -88,7 +88,7 @@ variable "oidc_eks_thumbprint" {
 variable "availability_zones" {
   description = "AZ to be used by EKS nodes"
   type        = "list"
-  default     = ["us-east-1a", "us-east-1c", "us-east-1d"]
+  default     = []
 }
 
 variable "domain_test" {


### PR DESCRIPTION
Remove dependency on hardcoded default AvailabilityZones. Replace
with dynamic lookup from current aws_availability_zones data source.
See upstream
https://github.com/uc-cdis/cloud-automation/pull/1573